### PR TITLE
density plot patch

### DIFF
--- a/R/plot-pgs.R
+++ b/R/plot-pgs.R
@@ -41,7 +41,8 @@ split.pgs.by.phenotype <- function(pgs, phenotype.data) {
             split.data <- aggregate(
                 x = pgs,
                 by = list(phenotype.column),
-                FUN = c
+                FUN = c,
+                simplify = FALSE
                 );
             split.data.list <- split.data$x;
             names(split.data.list) <- split.data$Group.1;
@@ -142,23 +143,28 @@ create.pgs.density.plot <- function(
                 max.lty <- 6;
                 max.categories <- max.colors * max.lty;
                 if (length(pgs.data.for.plotting) > max.categories) {
-                    # Issue a warning that plot is being skipped
-                    warning(paste0('Skipping plot for ', pgs.column, ' and ', phenotype, ' due to too many categories'));
-                    # replace with empty plot
+                    # Issue a warning that plot is not bein color-coded
+                    warning(paste0('Skipping colors for ', pgs.column, ' and ', phenotype, ' due to too many categories'));
+                    # plot all lines in black
                     pgs.density.by.phenotype.plots[[paste0(pgs.column,'_',phenotype)]] <- BoutrosLab.plotting.general::create.densityplot(
                         x = pgs.data.for.plotting,
                         ylab.label = NULL,
+                        xlab.label = phenotype,
                         main = pgs.column.main,
                         main.cex = titles.cex,
+                        xlab.cex = titles.cex,
                         yaxis.cex = yaxes.cex,
                         xaxis.cex = xaxes.cex,
-                        lwd = 0
+                        lwd = 2,
+                        col = 'black'
                         );
                     next;
                     }
 
                 if (length(pgs.data.for.plotting) > max.colors) {
-                    all.colors <- BoutrosLab.plotting.general::default.colours(max.colors);
+                    all.colors <- suppressWarnings( #suppress grey scale incompatibility warnings
+                        BoutrosLab.plotting.general::default.colours(max.colors)
+                        );
                     color.scheme.reps <- ceiling(length(pgs.data.for.plotting) / max.colors);
                     all.colors <- rep(all.colors, color.scheme.reps);
                     plot.colors <- all.colors[1:length(pgs.data.for.plotting)];

--- a/tests/testthat/test-plotting.R
+++ b/tests/testthat/test-plotting.R
@@ -125,6 +125,40 @@ test_that(
     );
 
 test_that(
+    'create.pgs.densityplot runs correctly with large number of phenotype categories', {
+        skip.plotting.tests(skip.plots = SKIP.PLOTS || SKIP.COMPREHENSIVE.CASES);
+
+        temp.dir <- tempdir();
+
+        # extend test data data frame by repeating itself a bunch of times
+        very.categorical.pgs.test <- pgs.test[rep(1:nrow(pgs.test), 73 * 4), ];
+        # simulate a PGS column
+        very.categorical.pgs.test$PGS <- rnorm(nrow(very.categorical.pgs.test));
+        # add more categories to categorical phenotype
+        very.categorical.pgs.test$very.categorical.phenotype <- as.character(rep(1:73, each = nrow(pgs.test)));
+
+        expect_warning(
+            create.pgs.density.plot(
+                pgs.data = very.categorical.pgs.test,
+                phenotype.columns = 'very.categorical.phenotype',
+                output.dir = temp.dir,
+                filename.prefix = 'TEST-many-categories'
+                )
+            );
+
+        test.filename <- generate.filename(
+            project.stem = 'TEST-many-categories',
+            file.core = 'pgs-density',
+            extension = 'png'
+            );
+        expect_true(
+            file.exists(file.path(temp.dir, test.filename))
+            );
+
+        }
+    );
+
+test_that(
     'create.pgs.density.plot runs correctly with tidy titles enabled', {
         skip.plotting.tests(skip.plots = SKIP.COMPREHENSIVE.CASES || SKIP.PLOTS);
 


### PR DESCRIPTION
This PR adds handling of categories exceeding the max number of default BPG colors.
- Increase max number of categories to 72 using color and line type combinations
- Handle greater than 72 categories by removing color coding
- Add tests for above

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [ ] I have added the changes included in this pull request to `NEWS` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in `metadata.yaml` and `DESCRIPTION`.

- [x] Both `R CMD build` and `R CMD check` run successfully.

<!--- Briefly describe the changes included in this pull request and the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...

## Testing Results
All tests pass