### PR TITLE
add path checking to all file import functions

### DIFF
--- a/R/handle-vcf.R
+++ b/R/handle-vcf.R
@@ -32,6 +32,12 @@ check.vcf.for.split.multiallelic.sites <- function(vcf.vcfR) {
 #' @return A list containing a tibble of VCF meta data and a tibble data.frame containing the parsed VCF data in long form.
 #' @export
 import.vcf <- function(vcf.path, info.fields = NULL, format.fields = NULL, verbose = FALSE) {
+
+    # check that vcf.path exists
+    if (!file.exists(vcf.path)) {
+        stop(paste0(vcf.path, ' does not exist.'));
+        }
+
     # import VCF file with vcfR
     vcf.vcfR <- vcfR::read.vcfR(file = vcf.path, convertNA = TRUE, verbose = verbose);
 

--- a/R/handle-weight-files.R
+++ b/R/handle-weight-files.R
@@ -39,6 +39,12 @@ open.input.connection <- function(input) {
 #' @return A data frame containing the metadata from the file header.
 #' @export
 parse.pgs.input.header <- function(pgs.weight.path) {
+
+    # check that pgs.weight.path exists
+    if (!file.exists(pgs.weight.path)) {
+        stop(paste0(pgs.weight.path, ' does not exist.'));
+        }
+
     # open file connection
     input.connection <- open.input.connection(input = pgs.weight.path);
 
@@ -70,6 +76,11 @@ parse.pgs.input.header <- function(pgs.weight.path) {
 #' @return A list containing the file metadata and the weight data.
 #' @export
 import.pgs.weight.file <- function(pgs.weight.path, use.harmonized.data = TRUE) {
+
+    # check that pgs.weight.path exists
+    if (!file.exists(pgs.weight.path)) {
+        stop(paste0(pgs.weight.path, ' does not exist.'));
+        }
 
     # parse file header
     file.metadata <- parse.pgs.input.header(pgs.weight.path = pgs.weight.path);

--- a/tests/testthat/test-pgs-import.R
+++ b/tests/testthat/test-pgs-import.R
@@ -64,6 +64,16 @@ test_that(
     );
 
 test_that(
+    'parse.pgs.input.header catches missing file', {
+        # check that an error is thrown
+        expect_error(
+            parse.pgs.input.header(pgs.weight.path = 'data/missing.file.txt'),
+            'data/missing.file.txt does not exist.'
+            );
+        }
+    );
+
+test_that(
     'parse.pgs.input.header works correctly on unzipped input', {
         load('data/import.test.data.Rda');
         expect_equal(
@@ -123,6 +133,16 @@ test_that(
             expected.colnames
             );
 
+        }
+    );
+
+test_that(
+    'import.pgs.weight.file catches missing file', {
+        # check that an error is thrown
+        expect_error(
+            import.pgs.weight.file(pgs.weight.path = 'data/missing.file.txt', use.harmonized.data = TRUE),
+            'data/missing.file.txt does not exist.'
+            );
         }
     );
 

--- a/tests/testthat/test-vcf-import.R
+++ b/tests/testthat/test-vcf-import.R
@@ -1,4 +1,14 @@
 test_that(
+    'import.vcf catches missing file', {
+        # check that an error is thrown
+        expect_error(
+            import.vcf(vcf.path = 'data/missing.file.vcf.gz'),
+            'data/missing.file.vcf.gz does not exist.'
+            );
+        }
+    );
+
+test_that(
     'import.vcf successfully imports VCF', {
         # check that correct input is accepted
         expect_no_error(


### PR DESCRIPTION
In debugging other things it has been annoying to discover that vcfR does not validate file paths, so adding that in to my wrapper + all other import functions.

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [ ] I have added the changes included in this pull request to `NEWS` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in `metadata.yaml` and `DESCRIPTION`.

- [x] Both `R CMD build` and `R CMD check` run successfully.

## Testing Results

All tests PASS