### PR TITLE
make rank barplot smaller

### DIFF
--- a/R/plot-pgs-rank.R
+++ b/R/plot-pgs-rank.R
@@ -660,7 +660,7 @@ create.pgs.rank.plot <- function(
         plot.heights[which(names(plot.list) == 'missing.genotypes.barplot')] <- 2;
         }
     if ('rank.barplot' %in% names(plot.list)) {
-        plot.heights[which(names(plot.list) == 'rank.barplot')] <- 5;
+        plot.heights[which(names(plot.list) == 'rank.barplot')] <- 2;
         }
 
     # Final multipanel plot


### PR DESCRIPTION
Received feedback that the rank barplot was taking up an unnecessarily large amount of space. Quick fix.

<!--- Please read each of the following items and confirm by replacing the [ ] with a [ ] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added the changes included in this pull request to `NEWS` under the next release version or unreleased, and updated the date.

- [x] I have updated the version number in `metadata.yaml` and `DESCRIPTION`.

- [ ] Both `R CMD build` and `R CMD check` run successfully.

<!--- Briefly describe the changes included in this pull request and the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...

## Testing Results
All tests pass