### PR TITLE
remove global variable settings

### DIFF
--- a/R/combine-vcf-with-pgs.R
+++ b/R/combine-vcf-with-pgs.R
@@ -1,4 +1,3 @@
-utils::globalVariables(c('ID', 'new.ID', '.')); # data table syntax work-around for CRAN legitimacy
 #' @title Combine VCF with PGS
 #' @description Match PGS SNPs to corresponding VCF information by genomic coordinates or rsID using a merge operation.
 #' @param vcf.data A data.frame containing VCF data. Required columns: \code{CHROM, POS}.


### PR DESCRIPTION
Removed one line of code defining globalVariables, leftover from data.table syntax which is now deprecated.
## Testing Results

All unit tests pass.