### PR TITLE
Bump R-CMD-check-action to v2

### DIFF
--- a/.github/workflows/r-lib-check.yaml
+++ b/.github/workflows/r-lib-check.yaml
@@ -15,4 +15,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: r-lib/actions/setup-tinytex@v2
-      - uses: uclahs-cds/tool-R-CMD-check-action@stable
+      - uses: uclahs-cds/tool-R-CMD-check-action@v2


### PR DESCRIPTION
This PR updates the `R CMD check` action to its newest `v2` release.
