### PR TITLE
fix code chunk in manual typo

### DIFF
--- a/R/apply-pgs.R
+++ b/R/apply-pgs.R
@@ -146,7 +146,7 @@ validate.phenotype.data.input <- function(phenotype.data, phenotype.analysis.col
 #' The PGS catalog standard column \code{other_allele} in \code{pgs.weight.data} is required for this check.
 #' @param remove.ambiguous.allele.matches A logical indicating whether to remove PGS variants with ambiguous allele matches between PGS weight data and VCF genotype data. Default is \code{FALSE}.
 #' The PGS catalog standard column \code{other_allele} in \code{pgs.weight.data} is required for this check.
-#' @param max.strand.flips An integer indicating the number of unambiguous strand flips that need to be detected in order to discard all variants with ambiguous allele matches. Only applies if {return.ambiguous.as.missing == TRUE}.
+#' @param max.strand.flips An integer indicating the number of unambiguous strand flips that need to be detected in order to discard all variants with ambiguous allele matches. Only applies if \code{return.ambiguous.as.missing == TRUE}.
 #' Default is \code{0} which means that all ambiguous variants are removed regardless of the status of any other variant.
 #' @param remove.mismatched.indels A logical indicating whether to remove indel variants that are mismatched between PGS weight data and VCF genotype data. Default is \code{FALSE}.
 #' The PGS catalog standard column \code{other_allele} in \code{pgs.weight.data} is required for this check.

--- a/R/assess-strand-flip.R
+++ b/R/assess-strand-flip.R
@@ -93,7 +93,7 @@ flip.DNA.allele <- function(alleles, return.indels.as.missing = FALSE) {
 #' @param return.indels.as.missing A logical value indicating whether to return NA for INDEL alleles with detected mismatches. Default is \code{FALSE}.
 #' @param return.ambiguous.as.missing A logical value indicating whether to return NA for ambiguous cases where both a strand flip and effect switch are possible,
 #' or no strand flip is detected and a mismatch cannot be resolved. Default is \code{FALSE}.
-#' @param max.strand.flips An integer indicating the number of non-ambiguous strand flips that must be present to implement the discarding all allele matches labeled "ambiguous_flip". Only applies if {return.ambiguous.as.missing == TRUE}.
+#' @param max.strand.flips An integer indicating the number of non-ambiguous strand flips that must be present to implement the discarding all allele matches labeled "ambiguous_flip". Only applies if \code{return.ambiguous.as.missing == TRUE}.
 #' Defaults to \code{0}, meaning that no strand flips are allowed. Allele matches labeled "unresolved_mismatch" are not affected by this parameter.
 #' @return A list containing the match assessment, a new PGS effect allele, and a new PGS other allele.
 #'

--- a/man/analyze.pgs.binary.predictiveness.Rd
+++ b/man/analyze.pgs.binary.predictiveness.Rd
@@ -25,7 +25,7 @@ analyze.pgs.binary.predictiveness(
 \item{pgs.data}{A data frame containing the PGS, phenotype, and covariate columns.}
 
 \item{pgs.columns}{A character vector specifying the names of the PGS columns
-in \code{data} to be analyzed. All specified columns must be numeric.}
+in \code{pgs.data} to be analyzed. All specified columns must be numeric.}
 
 \item{phenotype.columns}{A character vector specifying the names of the phenotype columns in \code{data} to be analyzed. If binary phenotypes are specified, they must be factors with two levels (0 and 1).}
 

--- a/man/apply.polygenic.score.Rd
+++ b/man/apply.polygenic.score.Rd
@@ -43,7 +43,7 @@ The PGS catalog standard column \code{other_allele} in \code{pgs.weight.data} is
 \item{remove.ambiguous.allele.matches}{A logical indicating whether to remove PGS variants with ambiguous allele matches between PGS weight data and VCF genotype data. Default is \code{FALSE}.
 The PGS catalog standard column \code{other_allele} in \code{pgs.weight.data} is required for this check.}
 
-\item{max.strand.flips}{An integer indicating the number of unambiguous strand flips that need to be detected in order to discard all variants with ambiguous allele matches. Only applies if {return.ambiguous.as.missing == TRUE}.
+\item{max.strand.flips}{An integer indicating the number of unambiguous strand flips that need to be detected in order to discard all variants with ambiguous allele matches. Only applies if \code{return.ambiguous.as.missing == TRUE}.
 Default is \code{0} which means that all ambiguous variants are removed regardless of the status of any other variant.}
 
 \item{remove.mismatched.indels}{A logical indicating whether to remove indel variants that are mismatched between PGS weight data and VCF genotype data. Default is \code{FALSE}.

--- a/man/assess.pgs.vcf.allele.match.Rd
+++ b/man/assess.pgs.vcf.allele.match.Rd
@@ -28,7 +28,7 @@ assess.pgs.vcf.allele.match(
 \item{return.ambiguous.as.missing}{A logical value indicating whether to return NA for ambiguous cases where both a strand flip and effect switch are possible,
 or no strand flip is detected and a mismatch cannot be resolved. Default is \code{FALSE}.}
 
-\item{max.strand.flips}{An integer indicating the number of non-ambiguous strand flips that must be present to implement the discarding all allele matches labeled "ambiguous_flip". Only applies if {return.ambiguous.as.missing == TRUE}.
+\item{max.strand.flips}{An integer indicating the number of non-ambiguous strand flips that must be present to implement the discarding all allele matches labeled "ambiguous_flip". Only applies if \code{return.ambiguous.as.missing == TRUE}.
 Defaults to \code{0}, meaning that no strand flips are allowed. Allele matches labeled "unresolved_mismatch" are not affected by this parameter.}
 }
 \value{


### PR DESCRIPTION
CRAN checks on v4.0.0 caught a typo in two sections of the manual: some curly braces intended to format the contents as code but without the actual `\code` indicator.

Should be fixed now in the `.R` and corresponding `.Rd` manual file.

<!--- Please read each of the following items and confirm by replacing the [ ] with a [ ] --->

- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [ ] I have added the changes included in this pull request to `NEWS` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in `metadata.yaml` and `DESCRIPTION`.

- [ ] Both `R CMD build` and `R CMD check` run successfully.

<!--- Briefly describe the changes included in this pull request and the test cases below
 !--- starting with 'Closes #...' if appropriate --->


## Testing Results

### Case 1
R CMD check passes locally.
