### PR TITLE
Fix CRAN vcfR issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ApplyPolygenicScore
 Type: Package
 Title: Utilities for the Application of a Polygenic Score to a VCF
-Version: 4.0.1
+Version: 4.0.2
 Authors@R: c(
     person('Paul', 'Boutros', role = 'cre', email = 'PBoutros@sbpdiscovery.org'),
     person('Nicole', 'Zeltser', role = 'aut', comment = c(ORCID = '0000-0001-7246-2771')),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 # ApplyPolygenicScore unreleased
 
+# ApplyPolygenicScore 4.0.2
+
+## Changed
+* Updated `import.vcf` INFO-field tests to be robust to upstream `vcfR::vcfR2tidy()` schema additions (e.g., `VariantKey`) and avoid CRAN failures.
+
 # ApplyPolygenicScore 4.0.1
 
 ## Changed

--- a/tests/testthat/test-vcf-import.R
+++ b/tests/testthat/test-vcf-import.R
@@ -247,26 +247,25 @@ test_that(
         expect_true(
             all(c('DPSum', 'platforms', 'arbitrated') %in% colnames(select.info.test.vcf$dat))
             );
+        all.info.columns <- c(
+            'DPSum', 'platforms', 'platformnames', 'platformbias', 'datasets',
+            'datasetnames', 'datasetsmissingcall', 'callsets', 'callsetnames',
+            'varType', 'filt', 'callable', 'difficultregion', 'arbitrated',
+            'callsetwiththisuniqgenopassing', 'callsetwithotheruniqgenopassing'
+            );
+        selected.info.columns <- c('DPSum', 'platforms', 'arbitrated');
+
         expect_true(
-            all(c('DPSum', 'platforms', 'platformnames', 'platformbias', 'datasets','datasetnames', 'datasetsmissingcall', 'callsets', 'callsetnames', 'varType','filt', 'callable', 'difficultregion', 'arbitrated', 'callsetwiththisuniqgenopassing', 'callsetwithotheruniqgenopassing') %in% colnames(all.info.test.vcf$dat))
+            all(all.info.columns %in% colnames(all.info.test.vcf$dat))
             );
 
-        # check that the total number of columns is correct
-        generic.vcf.ncol <- 7;
-        generic.vcfR.ncol <- 2;
-        info.ncol <- 16;
-        select.info.ncol <- 3;
-        format.ncol <- 6;
-        ncol.all <- generic.vcf.ncol + generic.vcfR.ncol + info.ncol + format.ncol;
-        ncol.select <- generic.vcf.ncol + generic.vcfR.ncol + select.info.ncol + format.ncol;
-
-        expect_equal(
-            ncol(select.info.test.vcf$dat),
-            ncol.select
+        # check that only selected INFO fields are included when info.fields is specified
+        expect_false(
+            any(setdiff(all.info.columns, selected.info.columns) %in% colnames(select.info.test.vcf$dat))
             );
         expect_equal(
-            ncol(all.info.test.vcf$dat),
-            ncol.all
+            ncol(all.info.test.vcf$dat) - ncol(select.info.test.vcf$dat),
+            length(setdiff(all.info.columns, selected.info.columns))
             );
 
         # check that one of the selected INFO columns has the correct value


### PR DESCRIPTION
Fixing a CRAN issue due to [recent changes in vcfR](https://github.com/knausb/vcfR/issues/214#issuecomment-2354043654)
```

    Running ‘testthat.R’ [129s/152s]
  Running the tests in ‘tests/testthat.R’ failed.
  Complete output:
    > library(testthat);
    > library(ApplyPolygenicScore);
    > 
    > test_check('ApplyPolygenicScore');
    Input data passed validation
    Input data passed validation
    Skipping test for >12 PGS columns as 'scales' package is available and will be used.
    [1] "springgreen3"
    [1] "darkturquoise"
    [1] "springgreen3"
    [1] "darkturquoise"
    Saving _problems/test-vcf-import-266.R
    Saving _problems/test-vcf-import-270.R
    [ FAIL 2 | WARN 87 | SKIP 0 | PASS 653 ]
    
    ══ Failed tests ════════════════════════════════════════════════════════════════
    ── Failure ('test-vcf-import.R:263:9'): import.vcf accurately imports INFO fields ──
    Expected `ncol(select.info.test.vcf$dat)` to equal `ncol.select`.
    Differences:
      `actual`: 19.0
    `expected`: 18.0
    
    ── Failure ('test-vcf-import.R:267:9'): import.vcf accurately imports INFO fields ──
    Expected `ncol(all.info.test.vcf$dat)` to equal `ncol.all`.
    Differences:
      `actual`: 32.0
    `expected`: 31.0
    
    
    [ FAIL 2 | WARN 87 | SKIP 0 | PASS 653 ]
    Error:
    ! Test failures.
    Execution halted
```
Updated INFO checks:

- Removed hard-coded total ncol expectations (these broke when upstream vcfR2tidy() added VariantKey).
- Kept checks that requested INFO fields exist.
- Added explicit check that non-requested INFO fields are absent when info.fields is specified.
- Replaced absolute column totals with a relative assertion:
  - ncol(all.info) - ncol(selected.info) == number of excluded INFO fields.

@alkaZeltser if you have time take a look that would be appreciated (I realize you may be busy prepping for your Defense)!